### PR TITLE
Fix issues:

### DIFF
--- a/vtStor.ATest/main.cpp
+++ b/vtStor.ATest/main.cpp
@@ -55,8 +55,9 @@ void main()
 
     // Call command
     //vtStor::Ata::IssueCommand_IdentifyDevice(drives[1], vtStor::cAta::s_DefaultCommandHandlerCommandType, dataBuffer);
+    vtStor::Ata::IssueCommand_ReadDma(drives[1], vtStor::cAta::s_DefaultCommandHandlerCommandType, dataBuffer, 0, 1);
     //vtStor::Ata::IssueCommand_ReadBuffer(drives[1], vtStor::cAta::s_DefaultCommandHandlerCommandType, dataBuffer);
-    vtStor::Ata::IssueCommand_Smart(drives[1], vtStor::cAta::s_DefaultCommandHandlerCommandType, dataBuffer, 208);
+    //vtStor::Ata::IssueCommand_Smart(drives[1], vtStor::cAta::s_DefaultCommandHandlerCommandType, dataBuffer, 208);
 
     vtStor::U8* data = dataBuffer->ToDataBuffer();
 

--- a/vtStor.ATest/vtStor.ATest.vcxproj
+++ b/vtStor.ATest/vtStor.ATest.vcxproj
@@ -72,22 +72,22 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(ProjectDir)$(Platform)$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(ProjectDir)$(Platform)$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(ProjectDir)$(Platform)$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(ProjectDir)$(Platform)$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/vtStor/CommandHandlerInterface.h
+++ b/vtStor/CommandHandlerInterface.h
@@ -40,7 +40,7 @@ public:
     virtual ~cCommandHandlerInterface();
 
 public:
-    virtual eErrorCode IssueCommand( std::shared_ptr<const cBufferInterface> CommandDescriptor, std::shared_ptr<cBufferInterface> Data ) = 0;
+    virtual eErrorCode IssueCommand( DeviceHandle Handle, std::shared_ptr<const cBufferInterface> CommandDescriptor, std::shared_ptr<cBufferInterface> Data ) = 0;
 
 protected:
     std::shared_ptr<Protocol::cProtocolInterface>   m_Protocol;

--- a/vtStor/Drive.cpp
+++ b/vtStor/Drive.cpp
@@ -41,13 +41,7 @@ void cDrive::RegisterCommandHandler(U32 CommandType, std::shared_ptr<cCommandHan
 
 eErrorCode cDrive::IssueCommand( U32 CommandType, std::shared_ptr<const cBufferInterface> CommandDescriptor, std::shared_ptr<cBufferInterface> Data )
 {
-    // set device handle into CommandDescriptor here
-    cCommandDescriptor commandDescriptor = cCommandDescriptor::Modifier(std::const_pointer_cast<cBufferInterface>(CommandDescriptor));
-
-    DeviceHandle& deviceHandle = commandDescriptor.GetDeviceHandle();
-    deviceHandle = m_DeviceHandle;
-
-    return( m_CommandHandlers[CommandType]->IssueCommand( CommandDescriptor, Data ) );
+    return( m_CommandHandlers[CommandType]->IssueCommand( m_DeviceHandle, CommandDescriptor, Data ) );
 }
 
 }

--- a/vtStor/DriveEnumeratorInterface.h
+++ b/vtStor/DriveEnumeratorInterface.h
@@ -33,7 +33,7 @@ public:
     static void* ToVoidPointer( std::shared_ptr<vtStor::cDriveEnumeratorInterface>& Object );
 
 public:
-    virtual eErrorCode EnumerateDrives( Vector_Drives& AddToList, U32& Count ) = 0;
+    virtual eErrorCode EnumerateDrives( std::vector<String> PathsList, Vector_Drives& AddToList, U32& Count ) = 0;
 
 public:
     virtual ~cDriveEnumeratorInterface();

--- a/vtStor/DriveManager.h
+++ b/vtStor/DriveManager.h
@@ -35,8 +35,14 @@ public:
 
     virtual std::shared_ptr<cDriveInterface> GetDrive(const U32 DriveIndex) override;
 
-public:
+private:
     cDriveManager();
+    static cDriveManager* single;
+
+public:
+    static std::unique_ptr<cDriveManager> getInstance();
+
+public:
     virtual ~cDriveManager();
 
 private:
@@ -45,6 +51,7 @@ private:
 
 private:
     Vector_Drives   m_Drives;
+    std::vector<String> m_DevicePaths;
 };
 
 }

--- a/vtStor/ProtocolInterface.h
+++ b/vtStor/ProtocolInterface.h
@@ -39,7 +39,7 @@ public:
     virtual ~cProtocolInterface();
 
 public:
-    virtual eErrorCode IssueCommand( std::shared_ptr<cBufferInterface> Essense, std::shared_ptr<cBufferInterface> DataBuffer ) = 0;
+    virtual eErrorCode IssueCommand( DeviceHandle Handle, std::shared_ptr<cBufferInterface> Essense, std::shared_ptr<cBufferInterface> DataBuffer ) = 0;
 };
 
 VTSTOR_API_EXPORT_IMPL template class VTSTOR_API std::shared_ptr<Protocol::cProtocolInterface>;

--- a/vtStor/vtStor.cpp
+++ b/vtStor/vtStor.cpp
@@ -23,7 +23,7 @@ using namespace vtStor;
 
 vtStor::eErrorCode vtStorInit(std::unique_ptr<vtStor::cDriveManagerInterface>& DriveManager)
 {
-    DriveManager = std::make_unique<cDriveManager>();
+    DriveManager = cDriveManager::getInstance();
 
     return(eErrorCode::None);
 }

--- a/vtStorAta/CommandHandlerAta.cpp
+++ b/vtStorAta/CommandHandlerAta.cpp
@@ -37,7 +37,7 @@ cCommandHandlerAta::~cCommandHandlerAta()
 {
 }
 
-eErrorCode cCommandHandlerAta::IssueCommand( std::shared_ptr<const cBufferInterface> CommandDescriptor, std::shared_ptr<cBufferInterface> Data )
+eErrorCode cCommandHandlerAta::IssueCommand( DeviceHandle Handle, std::shared_ptr<const cBufferInterface> CommandDescriptor, std::shared_ptr<cBufferInterface> Data )
 {
     eErrorCode errorCode = eErrorCode::None;
 
@@ -51,9 +51,6 @@ eErrorCode cCommandHandlerAta::IssueCommand( std::shared_ptr<const cBufferInterf
 
             std::shared_ptr<cBufferInterface> buffer = std::make_shared<cBuffer>(vtStor::Protocol::cEssenseAta1::SIZE_IN_BYTES);
             Protocol::cEssenseAta1 essense = Protocol::cEssenseAta1::Writer(buffer);
-    
-            DeviceHandle& deviceHandle = essense.GetDeviceHandle();
-            deviceHandle = commandDescriptor.GetDeviceHandle();
 
             StorageUtility::Ata::sCommandCharacteristic& commandCharacteristics = essense.GetCommandCharacteristics();
             commandCharacteristics = commandDescriptor.GetCommandCharacteristics();
@@ -62,7 +59,7 @@ eErrorCode cCommandHandlerAta::IssueCommand( std::shared_ptr<const cBufferInterf
             StorageUtility::Ata::uTaskFileRegister& taskFileExt = essense.GetTaskFileExt();
             PrepareTaskFileRegisters(commandCharacteristics, commandFields, taskFile, taskFileExt);
 
-            errorCode = m_Protocol->IssueCommand( buffer, Data );
+            errorCode = m_Protocol->IssueCommand( Handle, buffer, Data );
 
         } break;
 

--- a/vtStorAta/CommandHandlerAta.h
+++ b/vtStorAta/CommandHandlerAta.h
@@ -33,7 +33,7 @@ public:
     virtual ~cCommandHandlerAta();
 
 public:
-    virtual eErrorCode IssueCommand( std::shared_ptr<const cBufferInterface> CommandDescriptor, std::shared_ptr<cBufferInterface> Data ) override;
+    virtual eErrorCode IssueCommand( DeviceHandle Handle, std::shared_ptr<const cBufferInterface> CommandDescriptor, std::shared_ptr<cBufferInterface> Data ) override;
 
 private:
     void cCommandHandlerAta::PrepareTaskFileRegisters( const StorageUtility::Ata::sCommandCharacteristic& AtaCommandCharacteristics, const StorageUtility::Ata::uCommandFields& CommandFields, StorageUtility::Ata::uTaskFileRegister& TaskFileRegister, StorageUtility::Ata::uTaskFileRegister& TaskFileRegisterExt );

--- a/vtStorAta/DriveEnumeratorAta.cpp
+++ b/vtStorAta/DriveEnumeratorAta.cpp
@@ -32,16 +32,13 @@ cDriveEnumeratorAta::~cDriveEnumeratorAta()
 
 }
 
-eErrorCode cDriveEnumeratorAta::EnumerateDrives( Vector_Drives& AddToList, U32& Count )
+eErrorCode cDriveEnumeratorAta::EnumerateDrives(std::vector<String> PathsList, Vector_Drives& AddToList, U32& Count )
 {
     Count = 0;
-
-    std::vector<String> devicePaths;
-    vtStor::GetStorageDevicePaths( devicePaths, eOnErrorBehavior::Continue );
-
+    
     DeviceHandle deviceHandle;
     eErrorCode errorCode;
-    for ( const auto& devicePath : devicePaths )
+    for ( const auto& devicePath : PathsList )
     {
         errorCode = GetStorageDeviceHandle( devicePath, deviceHandle );
         if ( eErrorCode::None != errorCode )
@@ -64,6 +61,8 @@ eErrorCode cDriveEnumeratorAta::EnumerateDrives( Vector_Drives& AddToList, U32& 
             std::shared_ptr<cDriveInterface> drive = std::make_shared<cDriveAta>(std::make_shared<String>(devicePath));
 
             AddToList.push_back( drive );
+            devicePath.empty();
+
             ++Count;
         }
     }

--- a/vtStorAta/DriveEnumeratorAta.h
+++ b/vtStorAta/DriveEnumeratorAta.h
@@ -26,7 +26,7 @@ namespace vtStor
     class VT_STOR_ATA_API cDriveEnumeratorAta : public cDriveEnumeratorInterface
     {
     public:
-        virtual eErrorCode EnumerateDrives( Vector_Drives& AddToList, U32& Count ) override;
+        virtual eErrorCode EnumerateDrives( std::vector<String> PathsList, Vector_Drives& AddToList, U32& Count ) override;
 
     public:
         virtual ~cDriveEnumeratorAta();

--- a/vtStorAtaProtocol/Platform/Windows/ProtocolAtaPassThrough.cpp
+++ b/vtStorAtaProtocol/Platform/Windows/ProtocolAtaPassThrough.cpp
@@ -38,7 +38,7 @@ namespace Protocol
     const vtStor::U8 STATUS_REGISTER_OFFSET = 6;
     const vtStor::U8 RESERVED_REGISTER_OFFSET = 7;
     
-    eErrorCode cAtaPassThrough::IssueCommand( std::shared_ptr<cBufferInterface> Essense, std::shared_ptr<cBufferInterface> DataBuffer )
+    eErrorCode cAtaPassThrough::IssueCommand( DeviceHandle Handle, std::shared_ptr<cBufferInterface> Essense, std::shared_ptr<cBufferInterface> DataBuffer )
     {
         eErrorCode errorCode = eErrorCode::None;
 
@@ -50,7 +50,7 @@ namespace Protocol
             {
                 cEssenseAta1 essense = cEssenseAta1::Reader(Essense);
                 
-                m_DeviceHandle = essense.GetDeviceHandle();
+                m_DeviceHandle = Handle;
 
                 InitializePassThroughDirect(
                     essense.GetCommandCharacteristics(),

--- a/vtStorAtaProtocol/Platform/Windows/ProtocolAtaPassThrough.h
+++ b/vtStorAtaProtocol/Platform/Windows/ProtocolAtaPassThrough.h
@@ -39,7 +39,7 @@ class VT_STOR_ATA_PROTOCOL_API cAtaPassThrough : public cProtocolInterface
 {
 
 public:
-    virtual eErrorCode IssueCommand( std::shared_ptr<cBufferInterface> Essense, std::shared_ptr<cBufferInterface> DataBuffer ) override;
+    virtual eErrorCode IssueCommand( DeviceHandle Handle, std::shared_ptr<cBufferInterface> Essense, std::shared_ptr<cBufferInterface> DataBuffer ) override;
 
 private:
     void InitializePassThroughDirect(


### PR DESCRIPTION
+ Implement cDriveManager as a singleton
+ Remove device handle reference after call cDrive->IssueCommand() by let device handle as a parameter in CommandHandler and Protocol  IssueCommand()
+ Avoid duplicating a drive when enumerating use a common device paths.
Tested with some Ata commands